### PR TITLE
chore(deps): replace unused Renovate config with Dependabot, add PR title check

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,27 @@
+version: 2
+
+updates:
+  # yarn workspaces — root plus each package with its own manifest
+  - package-ecosystem: npm
+    directories:
+      - /
+      - /packages/toolkit
+      - /packages/cli
+      - /packages/docs
+    schedule:
+      interval: weekly
+    labels:
+      - dependencies
+    # Peer deps we wrap are pinned deliberately (ADR-009); bumping them is a
+    # decision, not a chore. Security updates still come through regardless.
+    open-pull-requests-limit: 5
+    groups:
+      dev-dependencies:
+        dependency-type: development
+
+  - package-ecosystem: github-actions
+    directory: /
+    schedule:
+      interval: weekly
+    labels:
+      - dependencies

--- a/.github/workflows/pr-title.yml
+++ b/.github/workflows/pr-title.yml
@@ -1,0 +1,25 @@
+name: PR Title
+
+on:
+  pull_request_target:
+    types: [opened, edited, reopened, synchronize]
+
+permissions:
+  pull-requests: read
+
+jobs:
+  conventional-commit:
+    runs-on: ubuntu-latest
+    steps:
+      # CONTRIBUTING.md requires conventional commits; nothing enforced it.
+      # Squash-merge uses the PR title as the commit subject, so checking the
+      # title is what actually keeps the convention true on main.
+      - uses: amannn/action-semantic-pull-request@v5
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          types: feat,fix,test,chore,refactor,docs,ci
+          requireScope: false
+          subjectPattern: ^(?![A-Z]).+[^.]$
+          subjectPatternError: |
+            "{subject}" must start lowercase and not end with a period.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -199,7 +199,7 @@ GitHub Actions: all above + coverage + Semgrep + bundle size + license check
 - Groq + OpenRouter for free AI in demos
 - Neon for default database (supports Supabase, AWS RDS, local Docker too)
 - GraphQL preferred over REST. MCP preferred over both.
-- Renovate for dependency monitoring
+- Dependabot for dependency monitoring
 
 ## Commit Rules
 - Use conventional commits: type(scope): description

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -48,7 +48,7 @@ The toolkit includes built-in security capabilities:
 
 ### Dependencies
 - All dependencies pinned to exact versions (no `^` ranges)
-- Renovate monitors for updates weekly
+- Dependabot opens weekly dependency PRs (`.github/dependabot.yml`) and security updates for known CVEs
 - License audit in CI (MIT, Apache-2.0, BSD, ISC only)
 - CodeQL analysis on every PR to `main`
 

--- a/SESSION_STATE.md
+++ b/SESSION_STATE.md
@@ -345,7 +345,7 @@ Phase 2 continues:
 | CONTRIBUTING.md | ✅ Full contributor guide |
 | SECURITY.md | ✅ Vulnerability reporting + features |
 | LICENSE | ✅ MIT |
-| Renovate | ✅ Pin strategy, weekly schedule |
+| Dependabot | ✅ Weekly npm + github-actions updates, security updates on |
 | Husky hooks | ✅ pre-commit (lint-staged), pre-push (test + build) |
 
 ## Published Versions

--- a/docs/CODING_PROCESS_AND_STANDARDS.md
+++ b/docs/CODING_PROCESS_AND_STANDARDS.md
@@ -151,7 +151,7 @@ test → build
 ### Versioning
 - Pin exact versions for direct and dev dependencies (no `^`, no `~`)
 - Peer dependencies use `>=` ranges (convention)
-- Renovate for automated dependency monitoring
+- Dependabot for automated dependency monitoring (`.github/dependabot.yml`)
 
 ### Adding Dependencies
 1. Check npm: version, last publish date, weekly downloads

--- a/renovate.json
+++ b/renovate.json
@@ -1,7 +1,0 @@
-{
-  "$schema": "https://docs.renovatebot.com/renovate-schema.json",
-  "extends": ["config:base"],
-  "rangeStrategy": "pin",
-  "labels": ["dependencies"],
-  "schedule": ["every weekend"]
-}


### PR DESCRIPTION
`renovate.json` has sat in this repo since March, correctly configured, and **the Renovate app was never installed** — `gh pr list --author "app/renovate"` returns zero PRs, ever. Meanwhile four live documents claimed it was monitoring dependencies weekly, including `SECURITY.md`.

## Changes

- **Delete `renovate.json`**, add `.github/dependabot.yml` — npm across all four workspace manifests plus `github-actions`, weekly, dev-deps grouped.
- **Correct the four live claims:** `SECURITY.md:51`, `CLAUDE.md:202`, `SESSION_STATE.md:348`, `docs/CODING_PROCESS_AND_STANDARDS.md:154`.
- **Add `.github/workflows/pr-title.yml`** — `CONTRIBUTING.md` requires conventional commits and nothing enforced it. Squash-merge uses the PR title as the commit subject, so checking the title is what actually keeps the convention true on `main`.

## Deliberately not changed

Four `Renovate` references survive, all in **changelogs** — `packages/toolkit/CHANGELOG.md:83,:136` and `packages/docs/content/docs/changelog.mdx:69,:122`. Those are historical records under released versions; the config genuinely did ship then. Rewriting a changelog to match present reality would be worse than leaving it. Flagging so the next reader doesn't think the sweep missed them.

`docs/CODING_PROCESS_AND_STANDARDS.md:153` (the stale `>=`-for-all peer-dep line) is untouched — #15 owns it.

## Also done outside this PR

Four free-for-public-repo protections were off and are now on: Dependabot alerts, Dependabot security updates, secret scanning, and secret-scanning push protection.

## Testing

- `git grep -in renovate` returns only the four changelog lines.
- Dependabot and the PR-title check both validate on this PR.

https://claude.ai/code/session_01Qm7sszajdk2UkWM6pCC1cd