### PR TITLE
docs(pr-template): trim checklist to human-judgment items

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -6,21 +6,23 @@
 
 <!-- Why is this change needed? Link to issue if applicable -->
 
+## Reviewer focus
+
+<!-- One sentence. Name ONE file, risk, or edge case to scrutinize. Not a list. -->
+
+## Key Decisions
+
+<!-- Max 3 bullets. Non-obvious choices only. -->
+
 ## Checklist
 
 - [ ] Tests added or updated (same commit as implementation)
-- [ ] No `any` in exported types (`unknown` + type guard if needed)
 - [ ] All exports have JSDoc with `@example` block
-- [ ] No raw `throw new Error()` — uses `ToolkitError`
-- [ ] No hardcoded provider URLs
-- [ ] No `process.exit()` in library code
-- [ ] No `^` in dependency versions (pin exact)
-- [ ] Input validation via Zod or type guard
-- [ ] `yarn test` — all passing
-- [ ] `yarn typecheck` — clean
-- [ ] `yarn lint` — no new warnings
-- [ ] Conventional commit messages used
+- [ ] Input validation via Zod schema or type guard
+
+CI enforces types, lint, tests, exact dependency pinning, and conventional commit
+format — you don't need to re-attest to those here.
 
 ## Test Plan
 
-<!-- How did you verify this works? -->
+<!-- Real, copy-pasteable commands. No placeholders. -->


### PR DESCRIPTION
## What

<!-- Brief description of the change -->

Trims the PR template checklist from 12 items to the 3 that need human judgment. Adds `Reviewer focus` and `Key Decisions` sections, each with a guidance comment.

## Why

<!-- Why is this change needed? Link to issue if applicable -->

Closes #33. Nine of the twelve boxes were already machine-enforced — `biome.json` (`noExplicitAny`), the `__verification__` semantic checks, `ci.yml`, and now `pr-title.yml`. Asking a contributor to re-attest what CI verifies trains ticking without reading, and buries the three that matter.

One box was hollow: **"No hardcoded provider URLs"** points at `config.getProviderUrl()`, which does not exist (#17), and its automated check matches nothing under any grep dialect (#5, confirmed on GNU grep 3.11 — a bare `|` in BRE is a literal pipe).

## Reviewer focus

<!-- One sentence. Name ONE file, risk, or edge case to scrutinize. Not a list. -->

The `Reviewer focus` guidance comment — if it doesn't state "one sentence, not a list", the section reliably becomes a bulleted list, which is the exact failure it exists to prevent.

## Key Decisions

<!-- Max 3 bullets. Non-obvious choices only. -->

- Kept `## What` / `## Why` / `## Test Plan` rather than renaming — this repo's existing headers, no reason to churn them.
- Dropped the provider-URL box outright rather than rewording it. Until #5 and #17 land there is nothing a contributor can check against.
- `Key Decisions` is capped at 3 bullets in the prompt; more than 3 usually means the PR is too large.

## Checklist

- [x] Tests added or updated (same commit as implementation) → n/a, template-only change
- [x] All exports have JSDoc with `@example` block → n/a, no code
- [x] Input validation via Zod schema or type guard → n/a, no code

## Test Plan

<!-- Real, copy-pasteable commands. No placeholders. -->

```bash
git grep -c '^- \[ \]' -- .github/PULL_REQUEST_TEMPLATE.md   # 3  (was 12)
git grep -n 'provider URLs' -- .github/PULL_REQUEST_TEMPLATE.md   # no output
git grep -c '<!--' -- .github/PULL_REQUEST_TEMPLATE.md       # 5  guidance comments restored
```

> **Note:** this PR's body was written by hand. The `quick_pull` link that opened it pre-filled `body=`, and GitHub only injects the template when the body would otherwise be empty — so the PR shipping the template was the first to bypass it. Same for any `gh pr create --body`. Worth a one-line instruction in `CLAUDE.md` so agents fill it; folded into #9/#17 rather than filed separately.

https://claude.ai/code/session_01Qm7sszajdk2UkWM6pCC1cd