### PR TITLE
fix(ci): pr-title types must be newline-separated, not comma

### DIFF
--- a/.github/workflows/pr-title.yml
+++ b/.github/workflows/pr-title.yml
@@ -18,7 +18,17 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:
-          types: feat,fix,test,chore,refactor,docs,ci
+          # ⛔ NEWLINE-separated, not comma. A comma string is parsed as ONE type
+          # literally named "feat,fix,...", so nothing matches and every PR fails.
+          # That shipped in #25 and broke every PR until #35.
+          types: |
+            feat
+            fix
+            test
+            chore
+            refactor
+            docs
+            ci
           requireScope: false
           subjectPattern: ^(?![A-Z]).+[^.]$
           subjectPatternError: |


### PR DESCRIPTION
## What

`types` in `pr-title.yml` was comma-separated. The action parses it as **newline-separated**, so it registered a single type literally named `feat,fix,test,chore,refactor,docs,ci` — which no title can match.

## Why

Every PR has been failing the `conventional-commit` check since #25 merged, including all five Dependabot PRs and #34. The error names the cause exactly:

```
Unknown release type "docs" found in pull request title "docs(pr-template): trim checklist..."
Available types:
 - feat,fix,test,chore,refactor,docs,ci     ← one item, not seven
```

It shipped untested because `pull_request_target` runs the workflow from the **base** branch — when #25 was open the file wasn't on `main` yet, so the check never ran on the PR that introduced it.

## Reviewer focus

This PR's own title (`fix(ci): ...`) is the test — if `conventional-commit` passes here, the list parses.

## Key Decisions

Left the comma→newline reason as a comment in the file, since the failure mode is silent from the YAML alone.

## Test Plan

```
gh pr checks <this PR>          # conventional-commit must pass
gh pr checks 34                 # re-run; must pass without editing the title
```

https://claude.ai/code/session_01Qm7sszajdk2UkWM6pCC1cd