### PR TITLE
fix(ci): skip claude review on dependabot PRs

### DIFF
--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -12,6 +12,13 @@ on:
 
 jobs:
   claude-review:
+    # Dependabot PRs cannot authenticate: GitHub withholds repository secrets from
+    # bot-triggered runs (they live in a separate Dependabot secrets store), so
+    # secrets.CLAUDE_CODE_OAUTH_TOKEN is empty and the action hard-fails on
+    # "Either ANTHROPIC_API_KEY, CLAUDE_CODE_OAUTH_TOKEN, or workload identity
+    # federation is required". Making it work means putting the token where
+    # bot-triggered code can read it — not worth it to review a lockfile bump.
+    if: github.actor != 'dependabot[bot]'
     # Optional: Filter by PR author
     # if: |
     #   github.event.pull_request.user.login == 'external-contributor' ||
@@ -40,10 +47,6 @@ jobs:
           plugins: 'code-review@claude-code-plugins'
           prompt: '/code-review:code-review --comment ${{ github.repository }}/pull/${{ github.event.pull_request.number }}'
           claude_args: '--allowedTools "mcp__github_inline_comment__create_inline_comment"'
-          # Dependabot opens PRs as a bot; without this the action hard-fails
-          # ("Workflow initiated by non-human actor"). Named explicitly — NOT '*',
-          # which the action's own docs warn lets external Apps invoke it on a public repo.
-          allowed_bots: 'dependabot[bot]'
           # ⚠️ track_progress was tried here and reverted. Observed: it flips
           # "Auto-detected mode" from agent to tag, and tag mode waits for an
           # @claude mention rather than auto-reviewing. NOT fully proven — both


### PR DESCRIPTION
## What

<!-- Brief description of the change -->

Replaces `allowed_bots: 'dependabot[bot]'` with `if: github.actor != 'dependabot[bot]'` on the review job.

## Why

<!-- Why is this change needed? Link to issue if applicable -->

`allowed_bots` (added in #26) let the job start on Dependabot PRs, then it failed on authentication:

```
Error: Either ANTHROPIC_API_KEY, CLAUDE_CODE_OAUTH_TOKEN, or workload identity
federation is required when using direct Anthropic API.
```

**GitHub withholds repository secrets from bot-triggered runs** — they live in a separate Dependabot secrets store — so `secrets.CLAUDE_CODE_OAUTH_TOKEN` is empty. #26 converted a clean skip into a red check on all six Dependabot PRs.

Making it work means copying the Claude OAuth token into a store readable by bot-triggered code on a public repo. Not worth it to review a lockfile bump.

## Reviewer focus

<!-- One sentence. Name ONE file, risk, or edge case to scrutinize. Not a list. -->

`if:` is on the job, not the step — a step-level guard would still spin up the runner and produce a green-but-empty job.

## Key Decisions

<!-- Max 3 bullets. Non-obvious choices only. -->

- Skip rather than authenticate: the security trade is the deciding factor, not the cost.
- Removed `allowed_bots` entirely rather than leaving it alongside the `if` — two mechanisms guarding one thing is how the next reader gets confused about which is load-bearing.

## Test Plan

<!-- Real, copy-pasteable commands. No placeholders. -->

```bash
# After merge, on any Dependabot PR:
gh pr checks 24 --repo danilobatson/ai-toolkit   # claude-review absent, not failing
```

https://claude.ai/code/session_01Qm7sszajdk2UkWM6pCC1cd