### PR TITLE
chore(ci): move to node 22

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,7 +11,7 @@ jobs:
       - uses: actions/checkout@v7
       - uses: actions/setup-node@v7
         with:
-          node-version: 20
+          node-version: 22
           cache: yarn
       - run: yarn install --frozen-lockfile
       - run: yarn typecheck

--- a/.github/workflows/scheduled.yml
+++ b/.github/workflows/scheduled.yml
@@ -12,7 +12,7 @@ jobs:
       - uses: actions/checkout@v7
       - uses: actions/setup-node@v7
         with:
-          node-version: 20
+          node-version: 22
           cache: yarn
       - run: yarn install --frozen-lockfile
       - run: yarn test

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -10,7 +10,7 @@ cd ai-toolkit
 yarn install
 ```
 
-**Requirements:** Node.js >= 20, Yarn 1.x
+**Requirements:** Node.js >= 22, Yarn 1.x
 
 ## Development
 

--- a/package.json
+++ b/package.json
@@ -32,6 +32,6 @@
   },
   "packageManager": "yarn@1.22.22",
   "engines": {
-    "node": ">=20.0.0"
+    "node": ">=22.0.0"
   }
 }


### PR DESCRIPTION
## What

<!-- Brief description of the change -->

Node 20 → 22 in `ci.yml`, `scheduled.yml`, `package.json` `engines`, and `CONTRIBUTING.md`.

## Why

<!-- Why is this change needed? Link to issue if applicable -->

#32's grouped dev-dependency bump fails install:

```
error lint-staged@17.4.1: The engine "node" is incompatible with this module.
Expected version ">=22.22.1". Got "20.20.2"
```

Independently, GitHub already warns on every run that **Node 20 is deprecated** and forces actions onto Node 24. This is overdue regardless of #32.

## Reviewer focus

<!-- One sentence. Name ONE file, risk, or edge case to scrutinize. Not a list. -->

`package.json` `engines` — bumping the CI runner without the declared minimum lets a contributor install on Node 20 and hit the same error locally that CI no longer catches.

## Key Decisions

<!-- Max 3 bullets. Non-obvious choices only. -->

- Chose 22 over 24: it's the minimum `lint-staged` 17 requires, and a smaller jump for anyone building locally. 24 can follow.
- Changed all four references in one commit — the runner and the declared minimum drifting apart is how "works in CI, fails locally" starts.

## Test Plan

<!-- Real, copy-pasteable commands. No placeholders. -->

```bash
gh pr checks <this PR>        # quality must pass on node 22
gh pr checks 32               # after merge + rebase, install must succeed
```

https://claude.ai/code/session_01Qm7sszajdk2UkWM6pCC1cd