### PR TITLE
fix(ci): skip claude review for all bot authors, not just dependabot

### DIFF
--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -12,13 +12,17 @@ on:
 
 jobs:
   claude-review:
-    # Dependabot PRs cannot authenticate: GitHub withholds repository secrets from
-    # bot-triggered runs (they live in a separate Dependabot secrets store), so
-    # secrets.CLAUDE_CODE_OAUTH_TOKEN is empty and the action hard-fails on
-    # "Either ANTHROPIC_API_KEY, CLAUDE_CODE_OAUTH_TOKEN, or workload identity
-    # federation is required". Making it work means putting the token where
-    # bot-triggered code can read it — not worth it to review a lockfile bump.
-    if: github.actor != 'dependabot[bot]'
+    # ⛔ Skip ALL bot-authored PRs, not just Dependabot. Two distinct failures,
+    # same root cause — a bot author cannot authenticate this action:
+    #   dependabot[bot]        → secrets withheld from bot-triggered runs, so
+    #                            CLAUDE_CODE_OAUTH_TOKEN is empty
+    #   anthropic-code-agent   → "App token exchange failed: 401 Unauthorized -
+    #                            User does not have write access" (PR #44)
+    # The first version of this guard named dependabot only and had to be widened
+    # when the second bot appeared. Match on author TYPE so the next one is covered.
+    # Review a bot's PR on demand instead: comment @claude on it — the mention fires
+    # as YOU, so secrets and write access resolve normally.
+    if: github.event.pull_request.user.type != 'Bot'
     # Optional: Filter by PR author
     # if: |
     #   github.event.pull_request.user.login == 'external-contributor' ||


### PR DESCRIPTION
## What

<!-- Brief description of the change -->

`if: github.actor != 'dependabot[bot]'` → `if: github.event.pull_request.user.type != 'Bot'`.

## Why

<!-- Why is this change needed? Link to issue if applicable -->

#36 named one bot. `anthropic-code-agent` then opened #44 and hit the same wall from a different angle:

```
App token exchange failed: 401 Unauthorized -
User does not have write access on this repository
```

Two bots, two distinct mechanisms — Dependabot gets no secrets, the agent has no write access — one root cause: **a bot author cannot authenticate this action.** Naming bots one at a time means widening this guard every time a new one appears; #36 was written four hours before #44 proved it too narrow.

## Reviewer focus

<!-- One sentence. Name ONE file, risk, or edge case to scrutinize. Not a list. -->

`github.event.pull_request.user.type` is the PR **author**, not the triggering actor — a human pushing to a bot-authored branch still skips, which is intended (the author is what the token exchange checks).

## Key Decisions

<!-- Max 3 bullets. Non-obvious choices only. -->

- Match on author type rather than an allowlist of bot names — an allowlist is the thing that just failed.
- Skip rather than authenticate: making either bot work means widening secret or write access on a public repo.
- On-demand review still works — commenting `@claude` on a bot's PR fires as the commenter, so secrets and write access resolve normally.

## Test Plan

<!-- Real, copy-pasteable commands. No placeholders. -->

```bash
gh pr checks 44 --repo danilobatson/ai-toolkit   # claude-review absent, not failing
gh pr list --repo danilobatson/ai-toolkit --author app/dependabot   # same on any future bump
```

https://claude.ai/code/session_01Qm7sszajdk2UkWM6pCC1cd