### PR TITLE
docs: tell agents how to open a PR here

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -201,6 +201,20 @@ GitHub Actions: all above + coverage + Semgrep + bundle size + license check
 - GraphQL preferred over REST. MCP preferred over both.
 - Dependabot for dependency monitoring
 
+## Opening a Pull Request
+
+Applies to anyone opening a PR here, agents included.
+
+- **Fill `.github/PULL_REQUEST_TEMPLATE.md`.** GitHub only injects it when the body
+  is empty, so `gh pr create --body`, API calls and pre-filled `quick_pull` links
+  all bypass it silently. Copy the sections and fill them.
+- **Open it ready for review, not as a draft**, and don't prefix the title `[WIP]`.
+  Open it when it's ready instead.
+- **Title must be a conventional commit** — `type(scope): subject`, lowercase subject,
+  no trailing period. `.github/workflows/pr-title.yml` enforces this and a
+  non-conforming title fails CI. Types: feat, fix, test, chore, refactor, docs, ci.
+- **`Reviewer focus` is one sentence naming one thing to scrutinize.** Not a list.
+
 ## Commit Rules
 - Use conventional commits: type(scope): description
 - NEVER include Co-Authored-By trailers in commits


### PR DESCRIPTION
## What

<!-- Brief description of the change -->

Adds an **Opening a Pull Request** section to `CLAUDE.md`.

## Why

<!-- Why is this change needed? Link to issue if applicable -->

Three annoyances with one cause — nothing told the agent our conventions:

| Symptom | Seen on |
|---|---|
| PR opens as `[WIP]` draft, needs manual ready-for-review | #44, #46 |
| Title isn't conventional-commit, fails `pr-title.yml` | #44 |
| PR template bypassed entirely | #34, #44, #46, and both of my own PRs |

The template one is structural: **GitHub only injects `PULL_REQUEST_TEMPLATE.md` when the body would otherwise be empty.** `gh pr create --body`, API creation, and pre-filled `quick_pull` links all skip it silently — so it applies to exactly one path, a human typing in the UI. `CLAUDE.md` is what the agent actually reads, so that's where the instruction belongs.

## Reviewer focus

<!-- One sentence. Name ONE file, risk, or edge case to scrutinize. Not a list. -->

Placement — this sits above `## Commit Rules`, in a file that #9 and #17 are both mid-surgery on; the new section is in a region neither of them touches.

## Key Decisions

<!-- Max 3 bullets. Non-obvious choices only. -->

- `CLAUDE.md` over `CONTRIBUTING.md`: the agent reads the former; the latter is for humans and #17 is already rewriting it.
- Stated *why* the template gets bypassed rather than just "use the template" — the silent-when-body-is-non-empty behavior is the part nobody would guess.

## Test Plan

<!-- Real, copy-pasteable commands. No placeholders. -->

```bash
# After merge, assign the agent to any issue and check its PR:
gh pr list --repo danilobatson/ai-toolkit --json number,title,isDraft
# expect: draft=false, conventional title, template sections in the body
```

https://claude.ai/code/session_01Qm7sszajdk2UkWM6pCC1cd