### PR TITLE
ci(claude): grant write so the mention path can open its own PR

### DIFF
--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -19,9 +19,16 @@ jobs:
       (github.event_name == 'issues' && (contains(github.event.issue.body, '@claude') || contains(github.event.issue.title, '@claude')))
     runs-on: ubuntu-latest
     permissions:
-      contents: read
-      pull-requests: read
-      issues: read
+      # write so @claude can push a branch AND open the PR itself. Read-only got
+      # us a branch plus a "Create PR" link (issue #33) — the last manual step.
+      # ⚠️ Public repo. This is safe only because the action itself gates on the
+      # TRIGGERING ACTOR's write access — a bot author was rejected on #44 with
+      # "App token exchange failed: 401 - User does not have write access".
+      # A drive-by commenter cannot drive it. Do not remove that assumption
+      # without re-checking it.
+      contents: write
+      pull-requests: write
+      issues: write
       id-token: write
       actions: read # Required for Claude to read CI results on PRs
     steps:


### PR DESCRIPTION
## What

<!-- Brief description of the change -->

`claude.yml`: `contents`, `pull-requests`, `issues` from `read` → `write`.

## Why

<!-- Why is this change needed? Link to issue if applicable -->

Option 1 (the `@claude` mention) produces a reviewed branch and commit, but stops at a **"Create PR" link** — one manual step. Option 2 (assigning the agent) opens the PR but costs three manual steps instead, all platform-fixed and not configurable: approve the workflow runs, retitle off `[WIP]` (it fails `pr-title.yml`), and mark ready for review. Neither `CLAUDE.md` (#47) nor the fork-PR approval policy changed any of that, because the `[WIP]` draft shell is created by GitHub's harness *before* the agent reads anything.

So write on the mention path is the remaining lever worth testing.

## Reviewer focus

<!-- One sentence. Name ONE file, risk, or edge case to scrutinize. Not a list. -->

Whether the actor gate is real — this is safe **only** because the action rejects actors without repo write access, evidenced by #44's `401 - User does not have write access` when a bot authored the PR.

## Key Decisions

<!-- Max 3 bullets. Non-obvious choices only. -->

- `issues: write` included so it can comment status and close issues it resolves; without it a `Closes #N` in a PR body still works but it can't report progress.
- Kept the reasoning as a comment in the file — the safety argument rests on an external behaviour (actor gating) that isn't visible from the YAML.

## Test Plan

<!-- Real, copy-pasteable commands. No placeholders. -->

```bash
# After merge, comment @claude on issue #13 asking it to open a PR:
gh pr list --repo danilobatson/ai-toolkit --json number,author,isDraft,title
# expect: a PR authored via the mention path, not a link to create one
```

https://claude.ai/code/session_01Qm7sszajdk2UkWM6pCC1cd