### PR TITLE
docs(security): link ADR-003 to penetration tests pinning its limitations

### DIFF
--- a/docs/adrs/003-regex-pii-detection-over-ml-models.md
+++ b/docs/adrs/003-regex-pii-detection-over-ml-models.md
@@ -56,3 +56,4 @@ The primary use case is **preventing obvious PII leakage** (SSNs, emails, phones
 - Works in all JavaScript runtimes including Edge
 - Users needing ML-grade detection can compose: `detectPII()` for fast scanning + external NER for deep analysis
 - Future: if demand warrants, we can add an optional `@jamaalbuilds/ai-toolkit-pii-ml` package with ML-based detection behind the same `PIIFinding` interface
+- The accepted limitations above (spelled-out, unicode-lookalike, reversed, and base64-encoded SSNs; homoglyph bypasses of blocked terms) are pinned as tests in `packages/toolkit/src/__security__/penetration.test.ts`

--- a/packages/docs/content/docs/architecture/adrs.mdx
+++ b/packages/docs/content/docs/architecture/adrs.mdx
@@ -23,7 +23,7 @@ These decisions were made during Phase 1 development and document the reasoning 
 
 **Decision:** Use regex-based PII detection instead of ML models (like Presidio).
 
-**Rationale:** Regex detection is zero-dependency, Edge-compatible, and fast. ML models require large binaries and Python interop. For a TypeScript toolkit, regex is the pragmatic choice. Trade-off: higher false positive rate, especially for names (Title Case patterns).
+**Rationale:** Regex detection is zero-dependency, Edge-compatible, and fast. ML models require large binaries and Python interop. For a TypeScript toolkit, regex is the pragmatic choice. Trade-off: higher false positive rate, especially for names (Title Case patterns). These accepted limitations are pinned as tests in `packages/toolkit/src/__security__/penetration.test.ts`.
 
 ### ADR-004: Langfuse Over LangSmith for Monitoring
 

--- a/packages/toolkit/src/__security__/penetration.test.ts
+++ b/packages/toolkit/src/__security__/penetration.test.ts
@@ -35,6 +35,7 @@ function stubDatabase(): DatabaseClient {
 
 describe("PII bypass attempts", () => {
 	describe("obfuscated SSN formats", () => {
+		// Accepted limitation — ADR-003 (regex over ML PII detection).
 		it("does NOT detect spelled-out SSN (known limitation — regex only)", () => {
 			// "one two three - four five - six seven eight nine"
 			// Regex-based PII detection intentionally does not parse English words.
@@ -46,6 +47,7 @@ describe("PII bypass attempts", () => {
 			expect(ssns).toHaveLength(0);
 		});
 
+		// Accepted limitation — ADR-003 (regex over ML PII detection).
 		it("does NOT detect unicode lookalike SSN (known limitation)", () => {
 			// Full-width digit ４ (U+FF14) mixed with ASCII digits
 			const findings = detectPII("123-\uFF145-6789");
@@ -53,6 +55,7 @@ describe("PII bypass attempts", () => {
 			expect(ssns).toHaveLength(0);
 		});
 
+		// Accepted limitation — ADR-003 (regex over ML PII detection).
 		it("does NOT detect reversed SSN (known limitation)", () => {
 			const findings = detectPII("9876-54-321");
 			const ssns = findings.filter((f) => f.type === "SSN");
@@ -74,6 +77,7 @@ describe("PII bypass attempts", () => {
 			expect(sanitized).not.toContain("123-45-6789");
 		});
 
+		// Accepted limitation — ADR-003 (regex over ML PII detection).
 		it("does NOT detect base64-encoded SSN (known limitation)", () => {
 			// "123-45-6789" base64-encoded is "MTIzLTQ1LTY3ODk="
 			const encoded = Buffer.from("123-45-6789").toString("base64");
@@ -224,6 +228,7 @@ describe("guardrail bypass attempts", () => {
 		expect(result.allowed).toBe(false);
 	});
 
+	// Accepted limitation — ADR-003 (regex over ML PII detection).
 	it("does NOT block unicode homoglyphs of blocked terms (known limitation)", () => {
 		// Replace 'a' with Cyrillic 'a' (U+0430) — visually identical
 		const result = blockedTerms.check("This is d\u0430ngerous content");


### PR DESCRIPTION
## What

Links ADR-003 to the five penetration tests that pin its accepted limitations. Adds a short comment above each of the five known-limitation tests in penetration.test.ts, a bullet in ADR-003 Consequences pointing to that file, and the same pointer in the published adrs.mdx summary.

## Why

Fixes #13. A reader hitting a known-limitation test had no way to tell it apart from an open security gap.

## Reviewer focus

Confirm the five ADR-003 comments land on exactly the five known-limitation tests named in the issue.

## Key Decisions

Used the issue text suggested comment on all five tests, including the guardrail homoglyph test, for consistency.

## Checklist

N/A, comment and doc only change; no tests, exports, or validation logic changed.

## Test Plan

git grep -c ADR-003 -- packages/toolkit/src/__security__/penetration.test.ts expected count 5. yarn and gh required approval unavailable in this sandbox so vitest was not re-run here, only comments were added and no test logic changed.

Generated with Claude Code https://claude.ai/code