### PR TITLE
ci(claude): allow gh pr and yarn so it can open PRs and run checks

### DIFF
--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -50,8 +50,13 @@ jobs:
           # Optional: Give a custom prompt to Claude. If this is not specified, Claude will perform the instructions specified in the comment that tagged it.
           # prompt: 'Update the pull request description to include a summary of changes.'
 
-          # Optional: Add claude_args to customize behavior and configuration
-          # See https://github.com/anthropics/claude-code-action/blob/main/docs/usage.md
-          # or https://code.claude.com/docs/en/cli-reference for available options
-          # claude_args: '--allowed-tools Bash(gh pr *)'
+          # Write permissions alone do NOT let it open a PR — the tool allowlist is
+          # the real gate. On issue #13 it pushed a branch, then reported:
+          #   "gh, yarn, npx and curl all required interactive approval that isn't
+          #    available here ... gh pr create would need to be added to this
+          #    workflow's allowed tools."
+          # gh pr/issue: open and comment on its own work.
+          # yarn:        run the checks CONTRIBUTING requires before a PR — it could
+          #              not run tests or lint on #13 and had to say so in the body.
+          claude_args: '--allowed-tools "Bash(gh pr:*),Bash(gh issue:*),Bash(yarn:*)"'
 


### PR DESCRIPTION
## What

<!-- Brief description of the change -->

Sets `claude_args: '--allowed-tools "Bash(gh pr:*),Bash(gh issue:*),Bash(yarn:*)"'` on the mention workflow — uncommenting the hint that already shipped in the file.

## Why

<!-- Why is this change needed? Link to issue if applicable -->

#49 granted `contents`/`pull-requests`/`issues: write` on the assumption that permissions blocked PR creation. **They didn't.** The run on issue #13 pushed a branch, then reported the real cause:

> `gh`, `yarn`, `npx` and `curl` all required interactive approval that isn't available here … `gh pr create` would need to be added to this workflow's allowed tools.

`yarn` is included for a second reason: on #13 it could not run lint, typecheck or tests, and had to say so in the PR body. `CONTRIBUTING.md` asks contributors to run those before opening a PR; without `yarn` in the allowlist that instruction is unfollowable.

## Reviewer focus

<!-- One sentence. Name ONE file, risk, or edge case to scrutinize. Not a list. -->

The allowlist is scoped to `gh pr:*` / `gh issue:*` rather than bare `gh` — `gh api` and `gh repo` stay out, so it cannot change repo settings or call arbitrary endpoints.

## Key Decisions

<!-- Max 3 bullets. Non-obvious choices only. -->

- Scoped subcommands rather than `Bash(gh:*)` — `gh api` would be a much wider grant than opening a PR needs.
- Kept #49's write permissions: they aren't sufficient on their own, but they are still necessary once the tool is allowed.
- Recorded the quote in a comment, because the failure is invisible from the YAML — the workflow looks capable without it.

## Test Plan

<!-- Real, copy-pasteable commands. No placeholders. -->

```bash
# After merge, comment @claude on an issue asking it to open a PR:
gh pr list --repo danilobatson/ai-toolkit --json number,author,title
# expect: a PR it opened, not a "Create PR" link in a comment
```

https://claude.ai/code/session_01Qm7sszajdk2UkWM6pCC1cd