### PR TITLE
docs(ci): correct the claim that a clean review posts nothing

### DIFF
--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -58,10 +58,12 @@ jobs:
           # (it refuses to run when a PR edits this file), so Claude never executed
           # in either. If you retry it, verify AFTER merging to main.
           #
-          # Open problem: a review that finds nothing posts nothing, so "reviewed,
-          # clean" and "never ran" look identical on the PR. Seen on #25 — a real
-          # review (4 turns, 15s) that left no trace outside the Actions log.
-          # use_sticky_comment is the untested candidate.
+          # ⛔ An earlier version of this comment claimed a clean review posts
+          # nothing. That was wrong. Per the docs, --comment posts an inline
+          # comment per finding OR one summary comment when it finds none.
+          # The real reason a PR can get no comment: Claude skips drafts, closed
+          # PRs, PRs it judges trivial or automated, and PRs it has already
+          # commented on. #25 was judged trivial — correct behaviour, not a gap.
           # See https://github.com/anthropics/claude-code-action/blob/main/docs/usage.md
           # or https://code.claude.com/docs/en/cli-reference for available options
 


### PR DESCRIPTION
## What

<!-- Brief description of the change -->

Replaces a false comment in `claude-code-review.yml` with what the docs actually say.

## Why

<!-- Why is this change needed? Link to issue if applicable -->

I wrote *"a review that finds nothing posts nothing, so 'reviewed, clean' and 'never ran' look identical"* into the workflow after #25 got no comment. The docs contradict it:

> `--comment`: Claude posts its review on the pull request, as an inline comment on each issue it finds **or as one summary comment when it finds none**.

> Claude skips draft and closed pull requests, pull requests **it judges not to need a review, such as automated or trivial ones**, and pull requests that already have a comment from Claude.

So #25 was skipped as trivial — correct behaviour. Our workflow already matches the current documented example (`@v1`, `--comment`, the inline-comment tool in `claude_args`), so nothing else needs changing.

Leaving a wrong explanation in the file is the same defect this repo's backlog exists to fix, so it goes.

## Reviewer focus

<!-- One sentence. Name ONE file, risk, or edge case to scrutinize. Not a list. -->

Whether the replacement states only what the docs support — the skip conditions are quoted, not inferred.

## Key Decisions

<!-- Max 3 bullets. Non-obvious choices only. -->

- Kept a note that the old claim was wrong rather than deleting silently, so nobody re-derives it from the same evidence.
- Did not add `use_sticky_comment`: the premise for it was the false claim.

## Test Plan

<!-- Real, copy-pasteable commands. No placeholders. -->

```bash
git grep -n "posts nothing" -- .github/workflows/   # no output
```

https://claude.ai/code/session_01Qm7sszajdk2UkWM6pCC1cd