### PR TITLE
chore: version .claude/settings.json and stop ignoring .claude/

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,0 +1,10 @@
+{
+  "$schema": "https://json.schemastore.org/claude-code-settings.json",
+  "permissions": {
+    "allow": [
+      "Bash(yarn:*)",
+      "Bash(gh pr:*)",
+      "Bash(gh issue:*)"
+    ]
+  }
+}

--- a/.gitignore
+++ b/.gitignore
@@ -32,13 +32,6 @@ coverage/
 # Docker
 *.log
 AUDIT_REPORT.md
-# Local Claude Code state stays ignored, but settings.json IS versioned: cloud
-# sessions read committed settings files, and that is the only documented way to
-# configure the tools available to an agent assigned to an issue.
-# Must be `.claude/*`, not `.claude/` — git cannot un-ignore a file inside an
-# ignored directory.
-.claude/*
-!.claude/settings.json
 AI_TOOLKIT_MASTERPLAN.md
 AI_TOOLKIT_PROMPTS.md
 SESSION_STATE.md

--- a/.gitignore
+++ b/.gitignore
@@ -32,7 +32,13 @@ coverage/
 # Docker
 *.log
 AUDIT_REPORT.md
-.claude/
+# Local Claude Code state stays ignored, but settings.json IS versioned: cloud
+# sessions read committed settings files, and that is the only documented way to
+# configure the tools available to an agent assigned to an issue.
+# Must be `.claude/*`, not `.claude/` — git cannot un-ignore a file inside an
+# ignored directory.
+.claude/*
+!.claude/settings.json
 AI_TOOLKIT_MASTERPLAN.md
 AI_TOOLKIT_PROMPTS.md
 SESSION_STATE.md


### PR DESCRIPTION
## What

<!-- Brief description of the change -->

Adds `.claude/settings.json` with a `permissions.allow` list, and narrows `.gitignore` so that one file is versioned while the rest of `.claude/` stays ignored.

## Why

<!-- Why is this change needed? Link to issue if applicable -->

An agent assigned to an issue has **no workflow file to configure** — it runs on GitHub's infrastructure, not `claude.yml`, so the tool allowlist that fixed the mention path (#51) never reaches it.

The Claude Code on the web docs give the only documented lever:

> To change settings for a cloud session, use environment variables or **commit settings files to the repository**.

> Subagents defined in your repo's `.claude/agents/` are picked up automatically.

This is an **experiment, not a fix** — whether an assigned agent is a cloud session is unverified.

**Falsifiable:** on #13 the mention path reported it could not run `yarn` and said so in its PR body. If the next assigned agent runs `yarn lint`/`yarn test` before opening its PR, settings are read. If it reports the same block, they aren't — equally worth knowing.

## Reviewer focus

<!-- One sentence. Name ONE file, risk, or edge case to scrutinize. Not a list. -->

The ignore rule must be `.claude/*`, not `.claude/` — git cannot un-ignore a file inside an ignored *directory*, so the negation only works against a contents glob.

## Key Decisions

<!-- Max 3 bullets. Non-obvious choices only. -->

- Versioned `settings.json` **only**; the broader "commit `.claude/skills/`" fork stays open in #19 and is not pre-empted.
- Allowlist mirrors #51 (`yarn`, `gh pr`, `gh issue`) so the paths are comparable — if behaviour differs, the difference is the runtime, not the config.
- Revert is one commit; nothing depends on it.

## Test Plan

<!-- Real, copy-pasteable commands. No placeholders. -->

```bash
git ls-files .claude/     # exactly one path: .claude/settings.json
# Then assign the agent to an issue and read its PR body for whether it ran yarn.
```

https://claude.ai/code/session_01Qm7sszajdk2UkWM6pCC1cd