### PR TITLE
ci(review): run review and ci on agent-authored prs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,8 +1,13 @@
 name: CI
 
+# `push` fires only for main. Every branch is covered by `pull_request` instead,
+# because a push made with GITHUB_TOKEN does not trigger `push` workflows — so
+# agent-opened PRs ran zero CI under the old `branches: ['**']`. PR #57's smoke
+# test never executed once. `pull_request` is not suppressed that way.
 on:
   push:
-    branches: ['**']
+    branches: [main]
+  pull_request:
 
 jobs:
   quality:

--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -12,22 +12,16 @@ on:
 
 jobs:
   claude-review:
-    # ⛔ Skip ALL bot-authored PRs, not just Dependabot. Two distinct failures,
-    # same root cause — a bot author cannot authenticate this action:
-    #   dependabot[bot]        → secrets withheld from bot-triggered runs, so
-    #                            CLAUDE_CODE_OAUTH_TOKEN is empty
-    #   anthropic-code-agent   → "App token exchange failed: 401 Unauthorized -
-    #                            User does not have write access" (PR #44)
-    # The first version of this guard named dependabot only and had to be widened
-    # when the second bot appeared. Match on author TYPE so the next one is covered.
-    # Review a bot's PR on demand instead: comment @claude on it — the mention fires
-    # as YOU, so secrets and write access resolve normally.
-    if: github.event.pull_request.user.type != 'Bot'
-    # Optional: Filter by PR author
-    # if: |
-    #   github.event.pull_request.user.login == 'external-contributor' ||
-    #   github.event.pull_request.user.login == 'new-developer' ||
-    #   github.event.pull_request.author_association == 'FIRST_TIME_CONTRIBUTOR'
+    # Skip Dependabot only. Its runs are structurally unauthenticatable: GitHub
+    # withholds secrets from Dependabot-triggered workflows, so
+    # CLAUDE_CODE_OAUTH_TOKEN is empty no matter what this file says.
+    #
+    # ⛔ Do NOT widen this to `user.type != 'Bot'`. That is what it used to say, and
+    # it silently excluded every agent-authored PR — the mention path opens as
+    # claude[bot], the assign path as Claude — so the PRs most worth reviewing were
+    # the only ones never reviewed. Bot authorship is not the failure; missing
+    # secrets are, and only Dependabot has that problem by construction.
+    if: github.event.pull_request.user.login != 'dependabot[bot]'
 
     runs-on: ubuntu-latest
     permissions:


### PR DESCRIPTION
## What

Two guards were silently excluding agent-opened PRs from every automated check.

1. **`claude-code-review.yml`** skipped on `user.type != 'Bot'`. Both agent paths open PRs as bots — the mention path as `claude[bot]`, the assign path as `Claude` — so #56 and #57 both reported `claude-review: skipping`. Narrowed to `dependabot[bot]`.
2. **`ci.yml`** was `on: push` only. A push made with `GITHUB_TOKEN` does not trigger `push` workflows, so mention-path PRs ran no CI whatsoever. Added `pull_request`; narrowed `push` to `main` to avoid double runs.

## Why

Only Dependabot has a structural reason to be skipped — GitHub withholds secrets from its runs, so the token is empty regardless of this file. Matching on author *type* generalised that one real cause into a blanket exclusion, and the PRs most worth reviewing became the only ones never reviewed.

The CI gap is the more serious of the two: `ci.yml` has never run on #57's branch, so the smoke test that PR adds — the entire deliverable of #2 — has not executed once. The assign path pushes with its own credentials and was unaffected, which is why this stayed invisible.

## Reviewer focus

Whether narrowing `push` to `main` leaves any branch uncovered — the intent is that `pull_request` picks up everything else.

## Test plan

- Merge, then confirm the next agent-opened PR reports `claude-review` as run rather than `skipping`, and shows a `quality` check.
- #57 is the live case: it currently has neither.

⚠️ This PR edits `claude-code-review.yml`, so the action's workflow-validation guard will refuse to review this PR itself. Expected — verification is on the next PR.

https://claude.ai/code/session_01Qm7sszajdk2UkWM6pCC1cd