### PR TITLE
docs(pr): cap pr descriptions at 200 words

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,10 +1,13 @@
+<!-- Ceiling: 200 words. Delete any section you would otherwise pad.
+     Only What and Why are required. The diff carries the detail. -->
+
 ## What
 
-<!-- Brief description of the change -->
+<!-- One sentence. -->
 
 ## Why
 
-<!-- Why is this change needed? Link to issue if applicable -->
+<!-- One or two sentences, plus the issue link. -->
 
 ## Reviewer focus
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -214,6 +214,14 @@ Applies to anyone opening a PR here, agents included.
   no trailing period. `.github/workflows/pr-title.yml` enforces this and a
   non-conforming title fails CI. Types: feat, fix, test, chore, refactor, docs, ci.
 - **`Reviewer focus` is one sentence naming one thing to scrutinize.** Not a list.
+- **Ceiling: 200 words.** The diff carries the detail; the description says what a
+  reviewer cannot get from the diff. Recent PRs ran 400-980 words, which is why this
+  is a number and not a preference.
+  - One sentence on what changed, one or two on why. Then stop.
+  - Cut anything the diff already says, reassurance, process narration, and notes on
+    what you did *not* do.
+  - Bullets and `inline code` over prose.
+  - **Delete a section rather than pad it.** Only `What` and `Why` are required.
 
 ## Commit Rules
 - Use conventional commits: type(scope): description


### PR DESCRIPTION
## What

A 200-word ceiling on PR descriptions, in `CLAUDE.md` and the PR template.

## Why

Recent PRs ran 400-980 words (#56 was 979). The template's six sections read as
six things to fill in, so they get filled. The ceiling is a number rather than a
preference because agents open most of these PRs and follow numbers better than taste.

## Reviewer focus

Whether 200 is too tight for a genuinely large change — nothing here overrides it.

## Test Plan

This description is 96 words. Next agent-opened PR is the real check.