### PR TITLE
fix(cache,storage): load optional peers with await import()

### DIFF
--- a/docs/CODING_PROCESS_AND_STANDARDS.md
+++ b/docs/CODING_PROCESS_AND_STANDARDS.md
@@ -152,6 +152,7 @@ test → build
 - Pin exact versions for direct and dev dependencies (no `^`, no `~`)
 - Peer dependencies use `>=` ranges (convention)
 - Dependabot for automated dependency monitoring (`.github/dependabot.yml`)
+- Optional peers load with `await import()`, never `require()` — the package ships as ESM, where `require` is undefined
 
 ### Adding Dependencies
 1. Check npm: version, last publish date, weekly downloads

--- a/packages/toolkit/src/cache/__tests__/redis-missing-dependency.test.ts
+++ b/packages/toolkit/src/cache/__tests__/redis-missing-dependency.test.ts
@@ -1,0 +1,25 @@
+import { describe, expect, it } from "vitest";
+import { CacheError } from "../../errors/types.js";
+import { RedisCacheAdapter } from "../client.js";
+
+// No vi.mock("ioredis", ...) here — ioredis is a peer dependency that is
+// not installed in this environment, so this exercises the real
+// "package genuinely missing" path through await import().
+describe("RedisCacheAdapter — ioredis not installed", () => {
+	it("CRASH — construction does not throw (loading is deferred)", () => {
+		expect(() => new RedisCacheAdapter("redis://localhost:6379")).not.toThrow();
+	});
+
+	it("ENVIRONMENT — get reports the missing dependency", async () => {
+		const cache = new RedisCacheAdapter("redis://localhost:6379");
+
+		try {
+			await cache.get("key1");
+			expect.unreachable("should have thrown");
+		} catch (err) {
+			expect(err).toBeInstanceOf(CacheError);
+			expect((err as CacheError).code).toBe("CACHE_MISSING_DEPENDENCY");
+			expect((err as CacheError).message).toMatch(/ioredis/i);
+		}
+	});
+});

--- a/packages/toolkit/src/cache/__tests__/redis.test.ts
+++ b/packages/toolkit/src/cache/__tests__/redis.test.ts
@@ -1,17 +1,6 @@
-import Module from "node:module";
-import {
-	afterAll,
-	beforeAll,
-	beforeEach,
-	describe,
-	expect,
-	it,
-	vi,
-} from "vitest";
+import { beforeEach, describe, expect, it, vi } from "vitest";
 import { CacheError } from "../../errors/types.js";
 
-// Mock ioredis via Module._load since cache/client.ts uses require() (CJS)
-// and vi.mock doesn't intercept native require() in ESM mode.
 const mockGet = vi.fn();
 const mockSet = vi.fn();
 const mockDel = vi.fn();
@@ -26,21 +15,9 @@ const MockRedis = vi.fn().mockImplementation(() => ({
 	quit: mockQuit,
 }));
 
-const originalLoad = Module._load;
-
-beforeAll(() => {
-	// @ts-expect-error — overriding internal API for test mocking
-	Module._load = function (request: string, parent: unknown, isMain: boolean) {
-		if (request === "ioredis") {
-			return MockRedis;
-		}
-		return originalLoad.call(this, request, parent, isMain);
-	};
-});
-
-afterAll(() => {
-	Module._load = originalLoad;
-});
+vi.mock("ioredis", () => ({
+	default: MockRedis,
+}));
 
 beforeEach(() => {
 	vi.clearAllMocks();

--- a/packages/toolkit/src/cache/client.ts
+++ b/packages/toolkit/src/cache/client.ts
@@ -98,44 +98,54 @@ export class MemoryCacheAdapter implements CacheClient {
  * Redis cache adapter for production.
  * Requires ioredis as a peer dependency.
  */
+interface RedisLike {
+	get(key: string): Promise<string | null>;
+	set(key: string, value: string, mode: string, ttl: number): Promise<unknown>;
+	del(...keys: string[]): Promise<number>;
+	keys(pattern: string): Promise<string[]>;
+	quit(): Promise<string>;
+}
+
 export class RedisCacheAdapter implements CacheClient {
-	private redis: {
-		get(key: string): Promise<string | null>;
-		set(
-			key: string,
-			value: string,
-			mode: string,
-			ttl: number,
-		): Promise<unknown>;
-		del(...keys: string[]): Promise<number>;
-		keys(pattern: string): Promise<string[]>;
-		quit(): Promise<string>;
-	};
+	private redisUrl: string;
 	private defaultTtl: number;
+	private redisPromise: Promise<RedisLike> | null = null;
 
 	constructor(redisUrl: string, options?: { defaultTtl?: number }) {
+		this.redisUrl = redisUrl;
 		this.defaultTtl = options?.defaultTtl ?? 300;
-		try {
-			// ioredis is a peer dependency — fail clearly if missing
-			// Variable indirection prevents TS from resolving the peer dep
-			const ioredisPath = "ioredis";
-			// eslint-disable-next-line @typescript-eslint/no-require-imports
-			const Redis = require(ioredisPath);
-			this.redis = new Redis(redisUrl, {
-				maxRetriesPerRequest: 3,
-				lazyConnect: true,
-			});
-		} catch {
-			throw new CacheError(
-				"Redis cache requires ioredis. Install it: yarn add ioredis",
-				{ code: "CACHE_MISSING_DEPENDENCY" },
-			);
+	}
+
+	// ioredis is a peer dependency — loaded lazily on first use since
+	// await import() cannot run inside a synchronous constructor.
+	private loadRedis(): Promise<RedisLike> {
+		if (!this.redisPromise) {
+			this.redisPromise = (async () => {
+				try {
+					// Variable indirection prevents TS from resolving the peer dep
+					const moduleName = "ioredis";
+					const mod = (await import(moduleName)) as {
+						default: new (url: string, opts: Record<string, unknown>) => RedisLike;
+					};
+					return new mod.default(this.redisUrl, {
+						maxRetriesPerRequest: 3,
+						lazyConnect: true,
+					});
+				} catch {
+					throw new CacheError(
+						"Redis cache requires ioredis. Install it: yarn add ioredis",
+						{ code: "CACHE_MISSING_DEPENDENCY" },
+					);
+				}
+			})();
 		}
+		return this.redisPromise;
 	}
 
 	async get<T = unknown>(key: string): Promise<T | null> {
+		const redis = await this.loadRedis();
 		try {
-			const value = await this.redis.get(key);
+			const value = await redis.get(key);
 			if (!value) return null;
 			return JSON.parse(value) as T;
 		} catch (error) {
@@ -151,9 +161,10 @@ export class RedisCacheAdapter implements CacheClient {
 		value: T,
 		options?: CacheOptions,
 	): Promise<void> {
+		const redis = await this.loadRedis();
 		const ttl = options?.ttl ?? this.defaultTtl;
 		try {
-			await this.redis.set(key, JSON.stringify(value), "EX", ttl);
+			await redis.set(key, JSON.stringify(value), "EX", ttl);
 		} catch (error) {
 			throw new CacheError(`Cache set failed for key: ${key}`, {
 				code: "CACHE_SET_FAILED",
@@ -163,8 +174,9 @@ export class RedisCacheAdapter implements CacheClient {
 	}
 
 	async invalidate(key: string): Promise<void> {
+		const redis = await this.loadRedis();
 		try {
-			await this.redis.del(key);
+			await redis.del(key);
 		} catch (error) {
 			throw new CacheError(`Cache invalidate failed for key: ${key}`, {
 				code: "CACHE_INVALIDATE_FAILED",
@@ -174,10 +186,11 @@ export class RedisCacheAdapter implements CacheClient {
 	}
 
 	async invalidatePrefix(prefix: string): Promise<void> {
+		const redis = await this.loadRedis();
 		try {
-			const keys = await this.redis.keys(`${prefix}*`);
+			const keys = await redis.keys(`${prefix}*`);
 			if (keys.length > 0) {
-				await this.redis.del(...keys);
+				await redis.del(...keys);
 			}
 		} catch (error) {
 			throw new CacheError(`Cache invalidatePrefix failed for: ${prefix}`, {
@@ -188,7 +201,8 @@ export class RedisCacheAdapter implements CacheClient {
 	}
 
 	async disconnect(): Promise<void> {
-		await this.redis.quit();
+		const redis = await this.loadRedis();
+		await redis.quit();
 	}
 }
 

--- a/packages/toolkit/src/storage/__tests__/blob-missing-dependency.test.ts
+++ b/packages/toolkit/src/storage/__tests__/blob-missing-dependency.test.ts
@@ -1,0 +1,38 @@
+import { describe, expect, it } from "vitest";
+import { StorageError } from "../../errors/types.js";
+import { deleteDocument, listDocuments, uploadDocument } from "../blob.js";
+
+// No vi.mock("@vercel/blob", ...) here — @vercel/blob is a peer dependency
+// that is not installed in this environment, so this exercises the real
+// "package genuinely missing" path through await import().
+describe("storage — @vercel/blob not installed", () => {
+	it("ENVIRONMENT — uploadDocument reports the missing dependency", async () => {
+		try {
+			await uploadDocument(Buffer.from("x"));
+			expect.unreachable("should have thrown");
+		} catch (err) {
+			expect(err).toBeInstanceOf(StorageError);
+			expect((err as StorageError).code).toBe("STORAGE_MISSING_DEPENDENCY");
+		}
+	});
+
+	it("ENVIRONMENT — deleteDocument reports the missing dependency", async () => {
+		try {
+			await deleteDocument("https://blob.vercel-storage.com/x.pdf");
+			expect.unreachable("should have thrown");
+		} catch (err) {
+			expect(err).toBeInstanceOf(StorageError);
+			expect((err as StorageError).code).toBe("STORAGE_MISSING_DEPENDENCY");
+		}
+	});
+
+	it("ENVIRONMENT — listDocuments reports the missing dependency", async () => {
+		try {
+			await listDocuments();
+			expect.unreachable("should have thrown");
+		} catch (err) {
+			expect(err).toBeInstanceOf(StorageError);
+			expect((err as StorageError).code).toBe("STORAGE_MISSING_DEPENDENCY");
+		}
+	});
+});

--- a/packages/toolkit/src/storage/__tests__/blob.test.ts
+++ b/packages/toolkit/src/storage/__tests__/blob.test.ts
@@ -1,36 +1,15 @@
-import Module from "node:module";
-import {
-	afterAll,
-	beforeAll,
-	beforeEach,
-	describe,
-	expect,
-	it,
-	vi,
-} from "vitest";
+import { beforeEach, describe, expect, it, vi } from "vitest";
 import { StorageError } from "../../errors/types.js";
 
-// Mock @vercel/blob via Module._load since blob.ts uses require() (CJS)
-// and vi.mock doesn't intercept native require() in ESM mode.
 const mockPut = vi.fn();
 const mockDel = vi.fn();
 const mockList = vi.fn();
 
-const originalLoad = Module._load;
-
-beforeAll(() => {
-	// @ts-expect-error — overriding internal API for test mocking
-	Module._load = function (request: string, parent: unknown, isMain: boolean) {
-		if (request === "@vercel/blob") {
-			return { put: mockPut, del: mockDel, list: mockList };
-		}
-		return originalLoad.call(this, request, parent, isMain);
-	};
-});
-
-afterAll(() => {
-	Module._load = originalLoad;
-});
+vi.mock("@vercel/blob", () => ({
+	put: mockPut,
+	del: mockDel,
+	list: mockList,
+}));
 
 beforeEach(() => {
 	vi.clearAllMocks();

--- a/packages/toolkit/src/storage/blob.ts
+++ b/packages/toolkit/src/storage/blob.ts
@@ -26,6 +26,30 @@ import { StorageError } from "../errors/types.js";
 // Variable indirection prevents TS from resolving the peer dep
 const VERCEL_BLOB_PATH = "@vercel/blob";
 
+interface VercelBlobModule {
+	put(
+		pathname: string,
+		body: unknown,
+		options: Record<string, unknown>,
+	): Promise<Record<string, unknown>>;
+	del(url: string): Promise<void>;
+	list(options: Record<string, unknown>): Promise<{
+		blobs: Array<Record<string, unknown>>;
+		cursor?: string;
+	}>;
+}
+
+async function loadVercelBlob(): Promise<VercelBlobModule> {
+	try {
+		return (await import(VERCEL_BLOB_PATH)) as unknown as VercelBlobModule;
+	} catch {
+		throw new StorageError(
+			"Vercel Blob not installed. Run: yarn add @vercel/blob",
+			{ code: "STORAGE_MISSING_DEPENDENCY" },
+		);
+	}
+}
+
 // ─── Types ──────────────────────────────────────────────────────────────────
 
 export interface FileValidationOptions {
@@ -125,22 +149,7 @@ export async function uploadDocument(
 	file: Blob | Buffer | ReadableStream,
 	options?: UploadOptions & { filename?: string; contentType?: string },
 ): Promise<UploadResult> {
-	let put: (
-		pathname: string,
-		body: unknown,
-		options: Record<string, unknown>,
-	) => Promise<Record<string, unknown>>;
-
-	try {
-		// eslint-disable-next-line @typescript-eslint/no-require-imports
-		const blob = require(VERCEL_BLOB_PATH);
-		put = blob.put;
-	} catch {
-		throw new StorageError(
-			"Vercel Blob not installed. Run: yarn add @vercel/blob",
-			{ code: "STORAGE_MISSING_DEPENDENCY" },
-		);
-	}
+	const blob = await loadVercelBlob();
 
 	const folder = options?.folder ?? "uploads";
 	const filename = options?.filename ?? `${Date.now()}-document`;
@@ -148,7 +157,7 @@ export async function uploadDocument(
 	const access = options?.access ?? "private";
 
 	try {
-		const result = await put(pathname, file, {
+		const result = await blob.put(pathname, file, {
 			access,
 			contentType: options?.contentType,
 		});
@@ -184,17 +193,10 @@ export async function uploadDocument(
  * ```
  */
 export async function deleteDocument(url: string): Promise<void> {
+	const blob = await loadVercelBlob();
 	try {
-		// eslint-disable-next-line @typescript-eslint/no-require-imports
-		const blob = require(VERCEL_BLOB_PATH);
 		await blob.del(url);
 	} catch (error) {
-		if (
-			error instanceof Error &&
-			"code" in error &&
-			(error as { code: string }).code === "STORAGE_MISSING_DEPENDENCY"
-		)
-			throw error;
 		throw new StorageError(
 			`Delete failed: ${error instanceof Error ? error.message : "Unknown error"}`,
 			{
@@ -223,9 +225,8 @@ export async function listDocuments(options?: {
 	blobs: Array<{ url: string; pathname: string; size: number }>;
 	cursor?: string;
 }> {
+	const blob = await loadVercelBlob();
 	try {
-		// eslint-disable-next-line @typescript-eslint/no-require-imports
-		const blob = require(VERCEL_BLOB_PATH);
 		const result = await blob.list({
 			prefix: options?.prefix,
 			limit: options?.limit ?? 100,


### PR DESCRIPTION
## What
Replace the four bare `require()` calls in `cache/client.ts` and `storage/blob.ts` with `await import()`, matching the pattern already used at the other 28 call sites.

## Why
The package ships as ESM, where `require` is undefined at runtime, so `uploadDocument`/`deleteDocument`/`listDocuments`/`new RedisCacheAdapter(url).get()` all threw instead of working, even with the peer installed. Closes #3.

## Reviewer focus
`RedisCacheAdapter` in `cache/client.ts` — its constructor can no longer `await`, so `ioredis` now loads lazily on first method call instead of at construction time.

## Key Decisions
- `RedisCacheAdapter` defers loading `ioredis` to first use instead of making the constructor async (constructors can't `await`) — `new RedisCacheAdapter(url)` stays synchronous.
- Test mocking moved from a `Module._load` monkeypatch to `vi.mock()`, matching `agents.test.ts`.
- No `smoke:dist` script exists in this checkout to verify against, so added dedicated tests exercising the real "package not installed" path — `ioredis`/`@vercel/blob` are genuinely absent here.

## Checklist
- [x] Tests added or updated (same commit as implementation)
- [x] All exports have JSDoc with `@example` block — n/a, no public API surface changed
- [x] Input validation via Zod schema or type guard — n/a, no new inputs added

## Test Plan
- `yarn typecheck`
- `yarn lint`
- `yarn test`
- `yarn build` then confirm `dist/cache/client.js` / `dist/storage/blob.js` contain no `require(`

Generated with [Claude Code](https://claude.ai/code)