### PR TITLE
docs: document createLLM alongside createAI

### DIFF
--- a/packages/toolkit/README.md
+++ b/packages/toolkit/README.md
@@ -92,6 +92,18 @@ const structured = await ai.structured('Extract the person', {
 console.log(structured.object); // { name: "...", age: ... }
 ```
 
+`createLLM` is also exported and still supported. It is the older client, kept
+so v4 code keeps working: it returns an `LLMClient` whose only method is
+`complete()`, with no streaming, structured output, or provider fallback.
+New code should use `createAI`.
+
+```typescript
+import { createLLM } from '@jamaalbuilds/ai-toolkit/ai';
+
+const llm = createLLM();
+const { content } = await llm.complete('Summarize this document.');
+```
+
 ## Chain — Prompt Templates, Parsing, RAG
 
 ```typescript


### PR DESCRIPTION
## What

Adds a short note and example for `createLLM` to the AI section of `packages/toolkit/README.md`.

## Why

`createAI` and `createLLM` are both exported from `src/ai/index.ts` and the root barrel, but the README mentioned `createAI` five times and `createLLM` zero times. A reader had no way to know the older client ships or when it applies. Three separate audit passes flagged the pair as intentional-but-undocumented.

## Reviewer focus

Whether the description of what `createLLM` lacks is accurate — `LLMClient` exposes only `complete()`, with no streaming, structured output, or provider fallback.

## Test plan

- `LLMResponse.content` exists (`src/ai/client.ts:59`), `config` is optional (`:155`), and `./ai` is a real subpath (`package.json:28`) — so the added example runs as written.