### PR TITLE
docs: note that observability is exported and deprecated

### DIFF
--- a/packages/toolkit/README.md
+++ b/packages/toolkit/README.md
@@ -68,6 +68,10 @@ import { createAgent } from '@jamaalbuilds/ai-toolkit/agents';
 | `data` | Shared API types (PaginatedResponse, ErrorResponse) | — | — |
 | `api` | HTTP client with retry | Custom | — |
 
+`observability` is also exported, and is deprecated — it re-exports from
+`monitor`, which is where new code should import from. That is why the
+`exports` map has 19 module subpaths while this table lists 18.
+
 ## AI — Generate, Stream, Structured Output
 
 ```typescript


### PR DESCRIPTION
## What

One line in the package README's Modules section explaining that `observability` is exported but deprecated.

## Why

The table lists 18 modules; `package.json` `exports` has 19 module subpaths. The nineteenth is the deprecated `observability` alias, omitted from the table with no explanation. That unexplained gap is what produced three different module counts across the docs (fixed in #82) — without a note, the next reader re-derives the same confusion.

## Reviewer focus

Whether 19-vs-18 is now answerable from the README alone.

## Test plan

- `packages/toolkit/package.json` exports 19 module subpaths; `src/observability/index.ts:2` marks it `@deprecated` pointing at `monitor`.