### PR TITLE
docs(changelog): record the maxTokens fix under 0.3.4

### DIFF
--- a/packages/toolkit/CHANGELOG.md
+++ b/packages/toolkit/CHANGELOG.md
@@ -24,6 +24,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   a literal pipe under BRE, and one treated a missing path as success.
 - Provider fallback in `generate()` and `structured()` could never fire — it
   excluded the only two error codes its loader throws.
+- `maxTokens` was silently discarded on every `generate()`, `stream()` and
+  `structured()` call. AI SDK v5 renamed the option to `maxOutputTokens`; the
+  toolkit still passed `maxTokens`, so the SDK ignored it and no token cap was
+  applied. `maxTokens` remains the toolkit's public option name and is now
+  mapped at the SDK boundary.
 
 ### Added
 - `yarn smoke:dist` executes the built artifact in CI, invoking the paths that


### PR DESCRIPTION
## What

Adds the `maxTokens` → `maxOutputTokens` fix (#115, PR #117) to the 0.3.4 changelog entry.

## Why

0.3.4 was tagged but never published — `npm view @jamaalbuilds/ai-toolkit version` still returns 0.3.3. The fix therefore belongs in the 0.3.4 entry rather than creating a 0.3.5 for a version nobody consumed. The `v0.3.4` tag needs moving to the final commit before publish.

## Reviewer focus

Whether folding into 0.3.4 rather than cutting 0.3.5 is right given nothing was published.

## Test plan

- `npm view @jamaalbuilds/ai-toolkit versions` lists up to 0.3.3 only.