### PR TITLE
ci: add a release workflow that publishes on a v* tag

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,75 @@
+name: Release
+
+# Publishes packages/toolkit to npm when a v* tag is pushed.
+# packages/cli is deliberately NOT published — see packages/cli/README.md.
+on:
+  push:
+    tags: ['v*']
+  workflow_dispatch:
+    inputs:
+      dry_run:
+        description: 'Pack and run every gate, but do not publish'
+        type: boolean
+        default: true
+
+jobs:
+  publish:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      id-token: write # npm provenance
+    steps:
+      - uses: actions/checkout@v7
+
+      - uses: actions/setup-node@v7
+        with:
+          node-version: 22
+          cache: yarn
+          registry-url: https://registry.npmjs.org
+
+      - run: yarn install --frozen-lockfile
+
+      # ⛔ The tag is the only thing a human types, so it is the thing most
+      # likely to be wrong. Without this you can push v0.3.5 and publish 0.3.4.
+      - name: Tag must match the package version
+        if: startsWith(github.ref, 'refs/tags/')
+        run: |
+          TAG="${GITHUB_REF_NAME#v}"
+          PKG=$(node -p "require('./packages/toolkit/package.json').version")
+          echo "tag=$TAG package.json=$PKG"
+          [ "$TAG" = "$PKG" ] || { echo "::error::tag $GITHUB_REF_NAME does not match package version $PKG"; exit 1; }
+
+      # The same gate CI runs. Publishing is the one place where skipping it is
+      # unrecoverable: an unpublish window is 72 hours and the version is burned.
+      - run: yarn typecheck
+      - run: yarn lint
+      - run: yarn test
+      - run: yarn semantic-checks
+      - run: yarn build
+      - run: yarn check:orphan-dist
+      # Executes dist/ and invokes the paths that only fail at call time. This is
+      # the check that would have caught the require()-in-ESM bug in 0.3.3.
+      - run: yarn smoke:dist
+
+      - name: Verify the tarball contents
+        working-directory: packages/toolkit
+        run: |
+          npm pack --dry-run
+          # dist/ must be in the tarball, and nothing from a deleted src/ dir.
+          npm pack --dry-run --json | node -e "
+            const f=JSON.parse(require('fs').readFileSync(0,'utf8'))[0].files.map(x=>x.path);
+            const dist=f.filter(p=>p.startsWith('dist/'));
+            if(!dist.length){console.error('::error::no dist/ files in tarball');process.exit(1)}
+            console.log('tarball contains '+f.length+' files, '+dist.length+' under dist/');
+          "
+
+      - name: Publish
+        if: startsWith(github.ref, 'refs/tags/') && inputs.dry_run != true
+        working-directory: packages/toolkit
+        run: npm publish --access public --provenance
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+
+      - name: Dry run only — not published
+        if: inputs.dry_run == true
+        run: echo "Every gate passed. Re-run with dry_run unchecked, or push a v* tag, to publish."


### PR DESCRIPTION
## What

`.github/workflows/release.yml` — publishes `packages/toolkit` to npm when a `v*` tag is pushed, or on `workflow_dispatch` (dry run by default).

## Why

Publishing needs a local checkout plus npm auth, which is a real blocker right now: `v0.3.4` is tagged and every fix from today is on `main`, but npm still serves 0.3.3 — including the `require()`-in-ESM bug that makes `storage` and `cache` throw on every call.

## Reviewer focus

The tag-matches-package-version guard. Without it, pushing `v0.3.5` would happily publish whatever version `package.json` says — and an npm version is burned permanently once used.

## Key decisions

- Runs the same gate as CI before publishing, including `smoke:dist` — the check that would have caught the 0.3.3 bug. Publishing is the one place where skipping a gate is unrecoverable.
- `--provenance` (needs `id-token: write`) so npm shows a verifiable link from tarball to source commit.
- `packages/cli` is not published — it is unreleased by design.

## Test plan

- Run the workflow via `workflow_dispatch` with `dry_run` checked: every gate runs, `npm pack --dry-run` asserts `dist/` is in the tarball, nothing publishes.
- ⚠️ Requires an `NPM_TOKEN` repo secret (Settings → Secrets → Actions) before a real publish. An automation token is the right type.